### PR TITLE
Fixed Lambda Layer and Function upload and download

### DIFF
--- a/.github/workflows/terraform-deploy.yml
+++ b/.github/workflows/terraform-deploy.yml
@@ -33,6 +33,12 @@ jobs:
       - name: Create Lambda Layer Payload
         run: cd package/ && zip -r lambda_layer_payload.zip python/ && cd ..
 
+      - name: Push Lambda Function Payload to S3
+        run: aws s3 cp src/lambda_function_payload.zip s3://garrettleber-tf-backend/prod/lambda-zips/lambda_function_payload.zip
+
+      - name: Push Lambda Layer Payload to S3
+        run: aws s3 cp package/lambda_layer_payload.zip s3://garrettleber-tf-backend/prod/lambda-zips/lambda_layer_payload.zip
+
       - name: Generate Lambda Function payload hash
         run: openssl dgst -sha256 -binary src/lambda_function_payload.zip | openssl enc -base64 | tr -d "\n" > src/lambda_function_payload.zip.base64sha256
 

--- a/lambda_deploy.tf
+++ b/lambda_deploy.tf
@@ -27,7 +27,7 @@ resource "aws_lambda_layer_version" "visitors_app_layer" {
   layer_name       = "visitors_app_layer"
   source_code_hash = data.aws_s3_bucket_object.visitors_app_layer_hash.body
   s3_bucket        = "garrettleber-tf-backend"
-  s3_key           = "prod/lambda-zips/lambda_layer_payload.zip.base64sha256"
+  s3_key           = "prod/lambda-zips/lambda_layer_payload.zip"
 
   compatible_runtimes = ["python3.8"]
 }
@@ -85,7 +85,7 @@ resource "aws_lambda_function" "visitorsapp" {
   source_code_hash = data.aws_s3_bucket_object.visitorsapp_function_hash.body
 
   s3_bucket = "garrettleber-tf-backend"
-  s3_key    = "prod/lambda-zips/lambda_function_payload.zip.base64sha256"
+  s3_key    = "prod/lambda-zips/lambda_function_payload.zip"
 
   runtime = "python3.8"
   layers  = [aws_lambda_layer_version.visitors_app_layer.arn]


### PR DESCRIPTION
Previously, tf was referencing the hash of each when intending to reference actual zip. Zip files also were not being pushed to S3, so that was also fixed.